### PR TITLE
[Task] Add librsvg2 to recommended packages

### DIFF
--- a/lib/Tool/Requirements.php
+++ b/lib/Tool/Requirements.php
@@ -442,6 +442,17 @@ final class Requirements
             ]);
         }
 
+        // librsvg2-bin
+        try {
+            $librsvgAvailable = \Pimcore\Tool\Console::getExecutable('rsvg-convert');
+        } catch (\Exception $e) {
+            $librsvgAvailable = false;
+        }
+        $checks[] = new Check([
+            'name' => 'librsvg2-bin',
+            'state' => $librsvgAvailable ? Check::STATE_OK : Check::STATE_WARNING,
+        ]);
+
         // timeout binary
         try {
             $timeoutBin = (bool) \Pimcore\Tool\Console::getTimeoutBinary();


### PR DESCRIPTION
librsvg2 is needed to calculate preview images for SVG files. Therefore it's added to the list of recommended packages, making it visible in the system check module and command.

<!--

Before working on a contribution, you must determine on which branch you need to work:
- Bug fix: choose the latest maintenance branch `11.3`
- Feature/Improvement: choose `11.x` 

> All bug fixes merged into the latest maintenance branch are also merged to the current dev branch (`11.x`) on a regular basis.

## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/` 
- [ ] Bugfixes need a short guide how to reproduce them -> target branch is the oldest supported maintenance branch, e.g. `11.3` (see Readme.md for the list of supported versions)
- [ ] Meet all coding standards (see PhpStan actions) 

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  

I had issues with my Pimcore installation not displaying preview images for SVG files in the backend.
After a couple of hours debugging I found out that the package "librsvg2-bin" is needed for it to work.

If I'm not wrong here, I think this should be added to the system requirements check tooling, so other people can get a better idea what may be missing in their setup, when they come across the same issue.

## Additional info

My local Pimcore environment runs with DDEV. After I configured the package to be installed, it worked fine.